### PR TITLE
Change array type to :array, handle null arrays and json

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -73,31 +73,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: hgdata/semantic-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_REPO_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          semantic_version: 16
-          branches: |
-            [
-              '+([0-9])?(.{+([0-9]),x}).x',
-              'main',
-              'next',
-              'next-major',
-              {
-                name: 'beta',
-                prerelease: true
-              },
-              {
-                name: 'alpha',
-                prerelease: true
-              }
-            ]
-          extra_plugins: |
-            @semantic-release/exec
-            @semantic-release/changelog
-            @semantic-release/github
-            @semantic-release/git
+          extends: |
+            @hgdata/semantic-release-config
 
       - name: Output Next Release Version
         id: get_next_version

--- a/lib/snowpack/odbc.ex
+++ b/lib/snowpack/odbc.ex
@@ -43,7 +43,7 @@ defmodule Snowpack.ODBC do
     {~r/DATE/, :date},
     {~r/TIME/, :time},
     {~r/OBJECT/, :json},
-    {~r/ARRAY/, :json}
+    {~r/ARRAY/, :array}
   ]
 
   ## Public API

--- a/lib/snowpack/type_parser.ex
+++ b/lib/snowpack/type_parser.ex
@@ -42,6 +42,10 @@ defmodule Snowpack.TypeParser do
 
   defp parse({:integer, data}) when is_binary(data), do: String.to_integer(data)
 
+  defp parse({:array, :null}), do: []
+  defp parse({:array, data}), do: Jason.decode!(data)
+
+  defp parse({:json, :null}), do: %{}
   defp parse({:json, data}), do: Jason.decode!(data)
 
   defp parse({_, data}) do


### PR DESCRIPTION
Snowpack was barfing when Snowflake returns a value of `NULL` in a column of type `ARRAY` (which we map to `:json` in snowpack). 

1. Handled null case for parsing column of type :json
    - This is the only required change, but 2 & 3 will make life easier in the platform
2. Changed ARRAY to map to type `:array` rather than json, so we can return [] rather than :null.
3. Handled null case for :array
