### PR TITLE
Signal connection to disconnect when a connection_closed error is received from ODBC

### DIFF
--- a/lib/snowpack/odbc.ex
+++ b/lib/snowpack/odbc.ex
@@ -116,22 +116,21 @@ defmodule Snowpack.ODBC do
   `pid` is the `:odbc` process id
   """
   # TODO: figure out how to test this correctly
-  # coveralls-ignore-start
   @spec disconnect(pid()) :: :ok
   def disconnect(pid) do
     GenServer.stop(pid, :normal)
   end
 
-  # coveralls-ignore-stop
-
   ## GenServer callbacks
 
+  @impl GenServer
   @spec init(keyword) :: {:ok, any}
   def init(opts) do
     send(self(), {:start, opts})
     {:ok, %{backoff: :backoff.init(2, 60), state: :not_connected}}
   end
 
+  @impl GenServer
   @spec handle_call(request :: term(), term(), state :: term()) ::
           {:noreply, term()}
           | {:noreply, term(), :hibernate | :infinity | non_neg_integer() | {:continue, term()}}
@@ -229,6 +228,7 @@ defmodule Snowpack.ODBC do
     end
   end
 
+  @impl GenServer
   @spec handle_info(msg :: :timeout | term(), state :: term()) ::
           {:noreply, term()}
           | {:noreply, term(), :hibernate | :infinity | non_neg_integer() | {:continue, term()}}
@@ -266,6 +266,7 @@ defmodule Snowpack.ODBC do
 
   # TODO: figure out how to test this correctly
   # coveralls-ignore-start
+  @impl GenServer
   @spec terminate(term(), state :: term()) :: term()
   def terminate(_reason, %{state: :not_connected} = _state), do: :ok
   def terminate(_reason, %{pid: pid} = _state), do: :odbc.disconnect(pid)

--- a/test/snowpack/odbc_test.exs
+++ b/test/snowpack/odbc_test.exs
@@ -5,11 +5,11 @@ defmodule Snowpack.ODBCTest do
 
   import Snowpack.TestHelper
 
+  setup :set_mimic_global
+
   @tag :capture_log
   test "handle_call/2 query when not_connected" do
-    Mimic.set_mimic_global()
-
-    expect(:odbc, :connect, fn _, _ -> {:error, "try again!"} end)
+    expect :odbc, :connect, fn _, _ -> {:error, "try again!"} end
 
     {:ok, pid} = start_supervised({Snowpack, key_pair_opts()})
 
@@ -18,9 +18,7 @@ defmodule Snowpack.ODBCTest do
 
   @tag :capture_log
   test "handle_call/2 query when with_query_id: false and error" do
-    Mimic.set_mimic_global()
-
-    expect(:odbc, :param_query, fn _, _, _, _ -> {:error, "bad things!"} end)
+    expect :odbc, :param_query, fn _, _, _, _ -> {:error, "bad things!"} end
 
     {:ok, pid} = start_supervised({Snowpack, key_pair_opts()})
 
@@ -29,10 +27,8 @@ defmodule Snowpack.ODBCTest do
 
   @tag :capture_log
   test "handle_call/2 query when last_query_id returns error" do
-    Mimic.set_mimic_global()
-
-    expect(:odbc, :sql_query, fn _, 'begin transaction;' -> :ok end)
-    expect(:odbc, :sql_query, fn _, 'SELECT LAST_QUERY_ID() as query_id;' -> {:error, :very_bad_things} end)
+    expect :odbc, :sql_query, fn _, 'begin transaction;' -> :ok end
+    expect :odbc, :sql_query, fn _, 'SELECT LAST_QUERY_ID() as query_id;' -> {:error, :very_bad_things} end
 
     {:ok, pid} = start_supervised({Snowpack, key_pair_opts()})
 

--- a/test/snowpack/protocol_test.exs
+++ b/test/snowpack/protocol_test.exs
@@ -1,36 +1,51 @@
 defmodule Snowpack.ProtocolTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   use Mimic
 
   import Snowpack.TestHelper
 
   describe "handle_execute/4" do
-    setup [:connect]
+    setup [:connect, :set_mimic_global]
 
+    @tag :capture_log
     test "with connection errors", %{pid: pid} do
-      expect(Snowpack.ODBC, :query, fn _pid, _statement, _params, _opts, _with_query_id ->
+      expect Snowpack.ODBC, :query, fn _pid, _statement, _params, _opts, _with_query_id ->
         {:error, Snowpack.Error.exception({"08123", "123", "bad"})}
-      end)
+      end
 
       assert {:error, %Snowpack.Error{odbc_code: :connection_exception}} = Snowpack.query(pid, "select 1;")
     end
 
+    @tag :capture_log
+    test "with connection_closed error ODBC is disconnected", %{pid: pid} do
+      expect Snowpack.ODBC, :query, fn _pid, _statement, _params, _opts, _with_query_id ->
+        {:error, Snowpack.Error.exception(:connection_closed)}
+      end
+
+      expect :odbc, :disconnect, fn _pid -> :ok end
+
+      assert {:error, %Snowpack.Error{message: "connection_closed"}} = Snowpack.query(pid, "select 1;")
+
+      # HACK: wait for DBConnection to process the disconnect
+      Process.sleep(500)
+    end
+
     test "updated with no query_id", %{pid: pid} do
       # Snowpack.ODBC.query is called with `with_query_id` set to false when the types are cached
-      expect(Snowpack.TypeCache, :get_column_types, fn _ -> {:ok, nil} end)
+      expect Snowpack.TypeCache, :get_column_types, fn _ -> {:ok, nil} end
 
-      expect(Snowpack.ODBC, :query, fn _pid, _statement, _params, _opts, false ->
+      expect Snowpack.ODBC, :query, fn _pid, _statement, _params, _opts, false ->
         {:updated, :undefined}
-      end)
+      end
 
       assert {:ok, %Snowpack.Result{num_rows: 0}} = Snowpack.query(pid, "begin transaction;")
     end
 
     test "updated with rows", %{pid: pid} do
-      expect(Snowpack.ODBC, :query, fn _pid, _statement, _params, _opts, true ->
+      expect Snowpack.ODBC, :query, fn _pid, _statement, _params, _opts, true ->
         {:updated, 1, [{"01a4456a-0401-73d1-0023-350366fe95b2"}]}
-      end)
+      end
 
       assert {:ok, %Snowpack.Result{num_rows: 1}} = Snowpack.query(pid, "insert into table (col) values (1)")
     end


### PR DESCRIPTION
Typically the `ping` that runs every second, by default, checks the connections and disconnects bad ones before they can be used. Because the `ping` cost $ in Snowflake we changed the ping to 5 minutes making it effectively useless. Now we are seeing bad connections being left in the pool and used.

This fix will do the disconnect when is query is made and return the error.

We should consider proactively retrying the query if the error is `connection_closed` so the caller doesn't have to know the internals of this.


