### PR TITLE
Add MERGE operation to ODBC no result bug list

### DIFF
--- a/lib/snowpack/odbc.ex
+++ b/lib/snowpack/odbc.ex
@@ -292,7 +292,7 @@ defmodule Snowpack.ODBC do
   end
 
   defp is_erlang_odbc_no_data_found_bug?(%Error{message: message}, statement) do
-    is_dml = statement =~ ~r/^(INSERT|UPDATE|DELETE)/i
+    is_dml = statement =~ ~r/^(INSERT|UPDATE|DELETE|MERGE)/i
     is_msg = message =~ "No SQL-driver information available."
 
     is_dml and is_msg


### PR DESCRIPTION
MERGE operations sometimes do not return the row result.

Relates to: https://github.com/HGInsights/snowpack/issues/41 and was fixed on https://github.com/HGInsights/snowpack/commit/18d5f8ccf0e35d303a8ec6df2e04eeb4a823ae7d